### PR TITLE
Stop skipping matching of request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,5 +163,9 @@ Additionally, Pretender doesn't allow for mocking JSONP or cross-origin ajax req
 
 ### Changelog
 
+##### V0.0.2
+- stop skipping data matches in schema validation plugin
+- if a request has data but the stub has none defined, it will now match that request to that stub
+
 ##### V0.0.1
 - initial release

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "main": [
     "dist/stubby-bundle.js"
   ],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/gocardless/stubby",
   "authors": [
     "Iain Nash <iain@gocardless.com>",

--- a/modules/schema-validator.js
+++ b/modules/schema-validator.js
@@ -22,13 +22,8 @@ var stubbySchemaValidatorModule = function(deps) {
     };
 
     this.register = function(handler) {
-      handler.on('setup', this.onRequestPrepare, this);
       handler.on('request', this.onRequestExecute, this);
       handler.on('routesetup', this.onRequestExecute, this);
-    };
-
-    this.onRequestPrepare = function(stub) {
-      stub.internal.skipDataMatch = true;
     };
 
     this.onRequestExecute = function(request, stub) {

--- a/spec/stubby.spec.js
+++ b/spec/stubby.spec.js
@@ -298,10 +298,22 @@ describe('stubbing a POST url', function() {
     });
   });
 
+  it('matches a stub if the stub has no data but the request does', function(done) {
+    stubby.stub({
+      url: '/foo',
+      method: 'POST'
+    }).respondWith(200, { a: 1 });
+
+    window.post({ url: '/foo', data: { b: 2 } }, function(xhr) {
+      expect(JSON.parse(xhr.responseText)).toEqual({ a: 1 });
+      done();
+    });
+  });
+
   it('can differentiate between POST and PUT data', function(done) {
     stubby.stub({
       url: '/foobar',
-      method: 'GET'
+      method: 'POST'
     }).respondWith(200, { method: 'get' });
 
     stubby.stub({

--- a/stubby.js
+++ b/stubby.js
@@ -100,7 +100,14 @@ var stubbyFactory = function(deps) {
       }
     });
 
-    var dataRequestMatch = _.isEqual(stub.request.data, data);
+    var dataRequestMatch;
+
+    // if no stub data was given, we just say that we matched
+    if (stub.request.data && !_.isEmpty(stub.request.data)) {
+      dataRequestMatch = _.isEqual(stub.request.data, data);
+    } else {
+      dataRequestMatch = true;
+    }
 
     var headersMatch = _.every(Object.keys(request.requestHeaders || {}), function(requestHeader) {
       var stubHeaderValue = stub.request.headers[requestHeader];


### PR DESCRIPTION
- if a stub doesn't specify `data`, but the request has it, just match as true anyway (so you don't have to define data of every POST request)
- remove the skipping of data matching if the stub is being validated

@harrison can you please review?